### PR TITLE
Access, refresh token 재발급 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign:4.1.3")
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")

--- a/src/main/kotlin/com/routebox/routebox/application/auth/AppleLoginUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/auth/AppleLoginUseCase.kt
@@ -6,7 +6,6 @@ import com.routebox.routebox.domain.auth.AuthService
 import com.routebox.routebox.domain.user.UserService
 import com.routebox.routebox.domain.user.constant.LoginType
 import com.routebox.routebox.exception.user.UserSocialLoginUidDuplicationException
-import com.routebox.routebox.security.JwtManager
 import jakarta.validation.Valid
 import org.springframework.stereotype.Component
 
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Component
 class AppleLoginUseCase(
     private val userService: UserService,
     private val authService: AuthService,
-    private val jwtManager: JwtManager,
 ) {
     /**
      * 애플 로그인.
@@ -44,8 +42,8 @@ class AppleLoginUseCase(
         return LoginResult(
             isNew = user.createdAt == user.updatedAt,
             loginType = LoginType.APPLE,
-            accessToken = jwtManager.createAccessToken(user.id, user.roles),
-            refreshToken = jwtManager.createRefreshToken(user.id, user.roles),
+            accessToken = authService.issueAccessToken(user),
+            refreshToken = authService.issueRefreshToken(user),
         )
     }
 }

--- a/src/main/kotlin/com/routebox/routebox/application/auth/AppleLoginUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/auth/AppleLoginUseCase.kt
@@ -8,6 +8,7 @@ import com.routebox.routebox.domain.user.constant.LoginType
 import com.routebox.routebox.exception.user.UserSocialLoginUidDuplicationException
 import jakarta.validation.Valid
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class AppleLoginUseCase(
@@ -26,6 +27,7 @@ class AppleLoginUseCase(
      * @param command
      * @return 로그인 결과로 신규 유저인지에 대한 정보, access token 정보, refresh token 정보를 응답한다.
      */
+    @Transactional
     operator fun invoke(@Valid command: AppleLoginCommand): LoginResult {
         val appleUserInfo = authService.getUserInfo(LoginType.APPLE, command.idToken)
 

--- a/src/main/kotlin/com/routebox/routebox/application/auth/KakaoLoginUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/auth/KakaoLoginUseCase.kt
@@ -6,7 +6,6 @@ import com.routebox.routebox.domain.auth.AuthService
 import com.routebox.routebox.domain.user.UserService
 import com.routebox.routebox.domain.user.constant.LoginType
 import com.routebox.routebox.exception.user.UserSocialLoginUidDuplicationException
-import com.routebox.routebox.security.JwtManager
 import jakarta.validation.Valid
 import org.springframework.stereotype.Component
 
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Component
 class KakaoLoginUseCase(
     private val userService: UserService,
     private val authService: AuthService,
-    private val jwtManager: JwtManager,
 ) {
     /**
      * 카카오 로그인.
@@ -44,8 +42,8 @@ class KakaoLoginUseCase(
         return LoginResult(
             isNew = user.createdAt == user.updatedAt,
             loginType = LoginType.KAKAO,
-            accessToken = jwtManager.createAccessToken(user.id, user.roles),
-            refreshToken = jwtManager.createRefreshToken(user.id, user.roles),
+            accessToken = authService.issueAccessToken(user),
+            refreshToken = authService.issueRefreshToken(user),
         )
     }
 }

--- a/src/main/kotlin/com/routebox/routebox/application/auth/KakaoLoginUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/auth/KakaoLoginUseCase.kt
@@ -8,6 +8,7 @@ import com.routebox.routebox.domain.user.constant.LoginType
 import com.routebox.routebox.exception.user.UserSocialLoginUidDuplicationException
 import jakarta.validation.Valid
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class KakaoLoginUseCase(
@@ -26,6 +27,7 @@ class KakaoLoginUseCase(
      * @param command
      * @return 로그인 결과로 신규 유저인지에 대한 정보, access token 정보, refresh token 정보를 응답한다.
      */
+    @Transactional
     operator fun invoke(@Valid command: KakaoLoginCommand): LoginResult {
         val kakaoUserInfo = authService.getUserInfo(LoginType.KAKAO, command.kakaoAccessToken)
 

--- a/src/main/kotlin/com/routebox/routebox/application/auth/RefreshTokensUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/auth/RefreshTokensUseCase.kt
@@ -1,0 +1,45 @@
+package com.routebox.routebox.application.auth
+
+import com.routebox.routebox.domain.auth.AuthService
+import com.routebox.routebox.domain.user.UserService
+import com.routebox.routebox.exception.security.InvalidTokenException
+import com.routebox.routebox.security.JwtInfo
+import com.routebox.routebox.security.JwtManager
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class RefreshTokensUseCase(
+    private val userService: UserService,
+    private val authService: AuthService,
+    private val jwtManager: JwtManager,
+) {
+    /**
+     * Access, refresh token을 재발급한다.
+     *
+     * @param refreshToken 토큰 재발급에 사용할, 유효한 refresh token
+     * @return access token, refresh token
+     * @throws InvalidTokenException token이 유효하지 않은 경우
+     */
+    @Transactional
+    operator fun invoke(refreshToken: String): Pair<JwtInfo, JwtInfo> {
+        val userId = jwtManager.getUserIdFromToken(refreshToken)
+        checkRefreshTokenAvailability(userId, refreshToken)
+
+        val user = userService.getUserById(userId)
+        return Pair(
+            authService.issueAccessToken(user),
+            authService.issueRefreshToken(user),
+        )
+    }
+
+    private fun checkRefreshTokenAvailability(userId: Long, refreshToken: String) {
+        val availableRefreshToken = authService.findAvailableRefreshToken(userId)
+
+        // 이용 가능한 refresh token이 없는 경우 => 토큰 재발급 불가능 (exception throw)
+        // 전달받은 refresh token이 토큰 재발급을 위해 사용 가능한 refresh token인지 검증
+        if (availableRefreshToken == null || availableRefreshToken != refreshToken) {
+            throw InvalidTokenException()
+        }
+    }
+}

--- a/src/main/kotlin/com/routebox/routebox/application/auth/dto/RefreshTokensCommand.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/auth/dto/RefreshTokensCommand.kt
@@ -1,0 +1,6 @@
+package com.routebox.routebox.application.auth.dto
+
+data class RefreshTokensCommand(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/src/main/kotlin/com/routebox/routebox/application/user/CheckNicknameAvailabilityUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/user/CheckNicknameAvailabilityUseCase.kt
@@ -2,9 +2,11 @@ package com.routebox.routebox.application.user
 
 import com.routebox.routebox.domain.user.UserService
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class CheckNicknameAvailabilityUseCase(private val userService: UserService) {
+    @Transactional(readOnly = true)
     operator fun invoke(nickname: String): Boolean =
         userService.isNicknameAvailable(nickname)
 }

--- a/src/main/kotlin/com/routebox/routebox/application/user/UpdateUserInfoUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/user/UpdateUserInfoUseCase.kt
@@ -5,6 +5,7 @@ import com.routebox.routebox.application.user.dto.UpdateUserInfoResult
 import com.routebox.routebox.domain.user.UserService
 import com.routebox.routebox.exception.user.UserNicknameDuplicationException
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class UpdateUserInfoUseCase(
@@ -18,6 +19,7 @@ class UpdateUserInfoUseCase(
      * @return 변경된 유저 정보
      * @throws UserNicknameDuplicationException 변경하려고 하는 닉네임이 이미 사용중인 경우
      */
+    @Transactional
     operator fun invoke(command: UpdateUserInfoCommand): UpdateUserInfoResult {
         val updatedUser = userService.updateUser(
             id = command.id,

--- a/src/main/kotlin/com/routebox/routebox/controller/auth/AuthController.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/auth/AuthController.kt
@@ -2,8 +2,14 @@ package com.routebox.routebox.controller.auth
 
 import com.routebox.routebox.application.auth.AppleLoginUseCase
 import com.routebox.routebox.application.auth.KakaoLoginUseCase
+import com.routebox.routebox.application.auth.RefreshTokensUseCase
 import com.routebox.routebox.application.auth.dto.AppleLoginCommand
 import com.routebox.routebox.application.auth.dto.KakaoLoginCommand
+import com.routebox.routebox.controller.auth.dto.AppleLoginRequest
+import com.routebox.routebox.controller.auth.dto.KakaoLoginRequest
+import com.routebox.routebox.controller.auth.dto.LoginResponse
+import com.routebox.routebox.controller.auth.dto.RefreshTokensRequest
+import com.routebox.routebox.controller.auth.dto.RefreshTokensResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -21,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 class AuthController(
     private val kakaoLoginUseCase: KakaoLoginUseCase,
     private val appleLoginUseCase: AppleLoginUseCase,
+    private val refreshTokensUseCase: RefreshTokensUseCase,
 ) {
     @Operation(
         summary = "카카오 로그인",
@@ -49,5 +56,20 @@ class AuthController(
     fun appleLoginV1(@RequestBody @Valid request: AppleLoginRequest): LoginResponse {
         val result = appleLoginUseCase(AppleLoginCommand(request.idToken))
         return LoginResponse.from(result)
+    }
+
+    @Operation(
+        summary = "토큰 재발급",
+        description = "<p>Refresh token으로 access token과 refresh token을 재발행합니다." +
+            "<p>토큰 재발급에 사용된 refresh token은 만료됩니다.(일회용)",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200"),
+        ApiResponse(responseCode = "401", description = "[2002] 토큰이 만료되었거나 유효하지 않은 경우", content = [Content()]),
+    )
+    @PostMapping("/v1/auth/tokens/refresh")
+    fun refreshTokensV1(@RequestBody @Valid request: RefreshTokensRequest): RefreshTokensResponse {
+        val (accessToken, refreshToken) = refreshTokensUseCase(request.refreshToken)
+        return RefreshTokensResponse(accessToken, refreshToken)
     }
 }

--- a/src/main/kotlin/com/routebox/routebox/controller/auth/dto/AppleLoginRequest.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/auth/dto/AppleLoginRequest.kt
@@ -1,4 +1,4 @@
-package com.routebox.routebox.controller.auth
+package com.routebox.routebox.controller.auth.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank

--- a/src/main/kotlin/com/routebox/routebox/controller/auth/dto/KakaoLoginRequest.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/auth/dto/KakaoLoginRequest.kt
@@ -1,4 +1,4 @@
-package com.routebox.routebox.controller.auth
+package com.routebox.routebox.controller.auth.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank

--- a/src/main/kotlin/com/routebox/routebox/controller/auth/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/auth/dto/LoginResponse.kt
@@ -1,4 +1,4 @@
-package com.routebox.routebox.controller.auth
+package com.routebox.routebox.controller.auth.dto
 
 import com.routebox.routebox.application.auth.dto.LoginResult
 import com.routebox.routebox.domain.user.constant.LoginType

--- a/src/main/kotlin/com/routebox/routebox/controller/auth/dto/RefreshTokensRequest.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/auth/dto/RefreshTokensRequest.kt
@@ -1,0 +1,13 @@
+package com.routebox.routebox.controller.auth.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+data class RefreshTokensRequest(
+    @Schema(
+        description = "토큰 재발급에 사용할, 유효한 refresh token",
+        example = "eyJ0eXAiOiJKV1QiLC.eyJzdWIiOiIxIiwicm9sZ.Fp7RNDCv9QQghS2cTC",
+    )
+    @field:NotBlank
+    val refreshToken: String,
+)

--- a/src/main/kotlin/com/routebox/routebox/controller/auth/dto/RefreshTokensResponse.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/auth/dto/RefreshTokensResponse.kt
@@ -1,0 +1,12 @@
+package com.routebox.routebox.controller.auth.dto
+
+import com.routebox.routebox.security.JwtInfo
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class RefreshTokensResponse(
+    @Schema(description = "Access token의 value와 만료 시각 정보")
+    val accessToken: JwtInfo,
+
+    @Schema(description = "Refresh token의 value와 만료 시각 정보")
+    val refreshToken: JwtInfo,
+)

--- a/src/main/kotlin/com/routebox/routebox/domain/auth/AuthService.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/auth/AuthService.kt
@@ -107,6 +107,16 @@ class AuthService(
             .getOrElse { ex -> throw RequestAppleAuthKeysException(ex.message, ex) }
 
     /**
+     * DB에서 관리하고 있는, 유저가 토큰 재발급에 이용 가능한 refresh token을 조회한다.
+     *
+     * @param userId id of user
+     * @return refresh token
+     */
+    @Transactional(readOnly = true)
+    fun findAvailableRefreshToken(userId: Long): String? =
+        refreshTokenRepository.findRefreshToken(userId)?.token
+
+    /**
      * Access token을 발행한다.
      *
      * @param user access token 발행에 필요한 유저 정보가 담긴 user entity

--- a/src/main/kotlin/com/routebox/routebox/domain/auth/RefreshToken.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/auth/RefreshToken.kt
@@ -2,6 +2,9 @@ package com.routebox.routebox.domain.auth
 
 // RTR(Refresh token rotation) 사용
 data class RefreshToken(
-    val userId: Long, // key
-    val token: String, // value
+    // key
+    val userId: Long,
+
+    // value
+    val token: String,
 )

--- a/src/main/kotlin/com/routebox/routebox/domain/auth/RefreshToken.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/auth/RefreshToken.kt
@@ -1,0 +1,7 @@
+package com.routebox.routebox.domain.auth
+
+// RTR(Refresh token rotation) 사용
+data class RefreshToken(
+    val userId: Long, // key
+    val token: String, // value
+)

--- a/src/main/kotlin/com/routebox/routebox/domain/auth/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/auth/RefreshTokenRepository.kt
@@ -1,5 +1,7 @@
 package com.routebox.routebox.domain.auth
 
 interface RefreshTokenRepository {
+    fun findRefreshToken(userId: Long): RefreshToken?
+
     fun save(refreshToken: RefreshToken)
 }

--- a/src/main/kotlin/com/routebox/routebox/domain/auth/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/auth/RefreshTokenRepository.kt
@@ -1,0 +1,5 @@
+package com.routebox.routebox.domain.auth
+
+interface RefreshTokenRepository {
+    fun save(refreshToken: RefreshToken)
+}

--- a/src/main/kotlin/com/routebox/routebox/exception/security/InvalidTokenException.kt
+++ b/src/main/kotlin/com/routebox/routebox/exception/security/InvalidTokenException.kt
@@ -4,7 +4,7 @@ import com.routebox.routebox.exception.CustomExceptionType
 import com.routebox.routebox.exception.common.UnauthorizedException
 
 class InvalidTokenException(
-    optionalMessage: String,
+    optionalMessage: String? = null,
     cause: Throwable? = null,
 ) : UnauthorizedException(
     exceptionType = CustomExceptionType.INVALID_TOKEN,

--- a/src/main/kotlin/com/routebox/routebox/infrastructure/auth/RefreshTokenRedisRepository.kt
+++ b/src/main/kotlin/com/routebox/routebox/infrastructure/auth/RefreshTokenRedisRepository.kt
@@ -1,0 +1,27 @@
+package com.routebox.routebox.infrastructure.auth
+
+import com.routebox.routebox.domain.auth.RefreshToken
+import com.routebox.routebox.domain.auth.RefreshTokenRepository
+import com.routebox.routebox.security.JwtManager
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Repository
+import java.util.concurrent.TimeUnit
+
+@Repository
+class RefreshTokenRedisRepository(
+    private val redisTemplate: RedisTemplate<String, String>,
+) : RefreshTokenRepository {
+
+    companion object {
+        private const val KEY_PREFIX = "refresh_token:"
+    }
+
+    override fun save(refreshToken: RefreshToken) {
+        redisTemplate.opsForValue().set(
+            KEY_PREFIX + refreshToken.userId,
+            refreshToken.token,
+            JwtManager.REFRESH_TOKEN_EXPIRED_DURATION_MILLIS,
+            TimeUnit.MILLISECONDS,
+        )
+    }
+}

--- a/src/main/kotlin/com/routebox/routebox/infrastructure/auth/RefreshTokenRedisRepository.kt
+++ b/src/main/kotlin/com/routebox/routebox/infrastructure/auth/RefreshTokenRedisRepository.kt
@@ -3,17 +3,21 @@ package com.routebox.routebox.infrastructure.auth
 import com.routebox.routebox.domain.auth.RefreshToken
 import com.routebox.routebox.domain.auth.RefreshTokenRepository
 import com.routebox.routebox.security.JwtManager
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Repository
 import java.util.concurrent.TimeUnit
 
 @Repository
-class RefreshTokenRedisRepository(
-    private val redisTemplate: RedisTemplate<String, String>,
-) : RefreshTokenRepository {
+class RefreshTokenRedisRepository @Autowired constructor(private val redisTemplate: RedisTemplate<String, String>) : RefreshTokenRepository {
 
     companion object {
         private const val KEY_PREFIX = "refresh_token:"
+    }
+
+    override fun findRefreshToken(userId: Long): RefreshToken? {
+        val tokenValue = redisTemplate.opsForValue().get(KEY_PREFIX + userId)
+        return if (tokenValue != null) RefreshToken(userId, tokenValue) else null
     }
 
     override fun save(refreshToken: RefreshToken) {

--- a/src/main/kotlin/com/routebox/routebox/logger/LogTraceAspect.kt
+++ b/src/main/kotlin/com/routebox/routebox/logger/LogTraceAspect.kt
@@ -17,14 +17,14 @@ class LogTraceAspect(
             "com.routebox.routebox.logger.Pointcuts.repositoryPoint()",
     )
     @Throws(Throwable::class)
-    fun execute(joinPoint: ProceedingJoinPoint): Any {
+    fun execute(joinPoint: ProceedingJoinPoint): Any? {
         var status: TraceStatus? = null
         try {
             val message = joinPoint.signature.toShortString()
             status = logTrace.begin(message)
 
             // Logic call
-            val result = joinPoint.proceed()
+            val result: Any? = joinPoint.proceed()
 
             logTrace.end(status)
             return result

--- a/src/main/kotlin/com/routebox/routebox/security/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/routebox/routebox/security/JwtAuthenticationFilter.kt
@@ -37,7 +37,7 @@ class JwtAuthenticationFilter(
         if (!accessToken.isNullOrBlank()) {
             try {
                 jwtManager.validate(accessToken)
-                val userId = jwtManager.getSubjectFromToken(accessToken)
+                val userId = jwtManager.getUserIdFromToken(accessToken)
                 val userDetails = userDetailsService.loadUserByUsername(userId)
                 val authentication = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
                 SecurityContextHolder.getContext().authentication = authentication

--- a/src/main/kotlin/com/routebox/routebox/security/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/routebox/routebox/security/JwtAuthenticationFilter.kt
@@ -38,7 +38,7 @@ class JwtAuthenticationFilter(
             try {
                 jwtManager.validate(accessToken)
                 val userId = jwtManager.getUserIdFromToken(accessToken)
-                val userDetails = userDetailsService.loadUserByUsername(userId)
+                val userDetails = userDetailsService.loadUserByUsername(userId.toString())
                 val authentication = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
                 SecurityContextHolder.getContext().authentication = authentication
             } catch (ignored: Exception) {

--- a/src/main/kotlin/com/routebox/routebox/security/JwtManager.kt
+++ b/src/main/kotlin/com/routebox/routebox/security/JwtManager.kt
@@ -25,8 +25,8 @@ class JwtManager(@Value("\${routebox.jwt.secret-key}") private val salt: String)
         private const val MILLISECONDS_IN_MINUTE: Long = 1000 * 60
         private const val MILLISECONDS_IN_HOUR: Long = 60 * MILLISECONDS_IN_MINUTE
         private const val MILLISECONDS_IN_DAY: Long = 24 * MILLISECONDS_IN_HOUR
-        private const val ACCESS_TOKEN_EXPIRED_DURATION: Long = 2 * MILLISECONDS_IN_HOUR
-        private const val REFRESH_TOKEN_EXPIRED_DURATION: Long = 30 * MILLISECONDS_IN_DAY
+        private const val ACCESS_TOKEN_EXPIRED_DURATION_MILLIS: Long = 2 * MILLISECONDS_IN_HOUR
+        const val REFRESH_TOKEN_EXPIRED_DURATION_MILLIS: Long = 30 * MILLISECONDS_IN_DAY
         private const val USER_ROLE_CLAIM_KEY = "role"
     }
 
@@ -46,10 +46,10 @@ class JwtManager(@Value("\${routebox.jwt.secret-key}") private val salt: String)
      * @param userId PK of user
      * @param userRoles roles of user
      * @return 생성된 access token 정보(토큰 값, 만료 시각)
-     * @see ACCESS_TOKEN_EXPIRED_DURATION access token 만료 기한
+     * @see ACCESS_TOKEN_EXPIRED_DURATION_MILLIS access token 만료 기한
      */
     fun createAccessToken(userId: Long, userRoles: Set<UserRoleType>): JwtInfo =
-        createToken(userId, userRoles, ACCESS_TOKEN_EXPIRED_DURATION)
+        createToken(userId, userRoles, ACCESS_TOKEN_EXPIRED_DURATION_MILLIS)
 
     /**
      * Refresh token 생성
@@ -57,10 +57,10 @@ class JwtManager(@Value("\${routebox.jwt.secret-key}") private val salt: String)
      * @param userId PK of user
      * @param userRoles roles of user
      * @return 생성된 refresh token 정보(토큰 값, 만료 시각)
-     * @see REFRESH_TOKEN_EXPIRED_DURATION refresh token 만료 기한
+     * @see REFRESH_TOKEN_EXPIRED_DURATION_MILLIS refresh token 만료 기한
      */
     fun createRefreshToken(userId: Long, userRoles: Set<UserRoleType>): JwtInfo =
-        createToken(userId, userRoles, REFRESH_TOKEN_EXPIRED_DURATION)
+        createToken(userId, userRoles, REFRESH_TOKEN_EXPIRED_DURATION_MILLIS)
 
     /**
      * JWT 생성
@@ -93,7 +93,7 @@ class JwtManager(@Value("\${routebox.jwt.secret-key}") private val salt: String)
      * @param token subject를 추출할 token
      * @return 추출한 subject(userId)
      */
-    fun getSubjectFromToken(token: String): String = getClaimsFromToken(token).subject
+    fun getUserIdFromToken(token: String): String = getClaimsFromToken(token).subject
 
     private fun getClaimsFromToken(token: String): Claims = getJwsFromToken(token).body
 

--- a/src/main/kotlin/com/routebox/routebox/security/JwtManager.kt
+++ b/src/main/kotlin/com/routebox/routebox/security/JwtManager.kt
@@ -93,9 +93,11 @@ class JwtManager(@Value("\${routebox.jwt.secret-key}") private val salt: String)
      * @param token subject를 추출할 token
      * @return 추출한 subject(userId)
      */
-    fun getUserIdFromToken(token: String): String = getClaimsFromToken(token).subject
+    fun getUserIdFromToken(token: String): Long =
+        getClaimsFromToken(token).subject.toLong()
 
-    private fun getClaimsFromToken(token: String): Claims = getJwsFromToken(token).body
+    private fun getClaimsFromToken(token: String): Claims =
+        getJwsFromToken(token).body
 
     private fun getJwsFromToken(token: String): Jws<Claims> =
         Jwts.parserBuilder()

--- a/src/main/kotlin/com/routebox/routebox/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/routebox/routebox/security/SecurityConfig.kt
@@ -25,6 +25,7 @@ class SecurityConfig {
         private val AUTH_WHITE_LIST = mapOf(
             "/api/v1/auth/login/kakao" to HttpMethod.POST,
             "/api/v1/auth/login/apple" to HttpMethod.POST,
+            "/api/v1/auth/tokens/refresh" to HttpMethod.POST,
             "/api/v1/users/nickname/*/availability" to HttpMethod.GET,
         )
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,10 @@ spring:
                 format_sql: false
                 default_batch_fetch_size: 100
         defer-datasource-initialization: false
+    data:
+        redis:
+            host: ${REDIS_HOST}
+            port: ${REDIS_PORT}
 
 logging:
     level:

--- a/src/test/kotlin/com/routebox/routebox/application/auth/AppleLoginUseCaseTest.kt
+++ b/src/test/kotlin/com/routebox/routebox/application/auth/AppleLoginUseCaseTest.kt
@@ -48,8 +48,8 @@ class AppleLoginUseCaseTest {
         given(authService.getUserInfo(LoginType.APPLE, appleIdToken))
             .willReturn(OAuthUserInfo(uid = appleUid))
         given(userService.createNewUser(LoginType.APPLE, appleUid)).willReturn(newUser)
-        given(jwtManager.createAccessToken(newUser.id, newUser.roles)).willReturn(expectedAccessTokenResult)
-        given(jwtManager.createRefreshToken(newUser.id, newUser.roles)).willReturn(expectedRefreshTokenResult)
+        given(authService.issueAccessToken(newUser)).willReturn(expectedAccessTokenResult)
+        given(authService.issueRefreshToken(newUser)).willReturn(expectedRefreshTokenResult)
 
         // when
         val result = sut.invoke(AppleLoginCommand(appleIdToken))
@@ -57,8 +57,8 @@ class AppleLoginUseCaseTest {
         // then
         then(authService).should().getUserInfo(LoginType.APPLE, appleIdToken)
         then(userService).should().createNewUser(LoginType.APPLE, appleUid)
-        then(jwtManager).should().createAccessToken(newUser.id, newUser.roles)
-        then(jwtManager).should().createRefreshToken(newUser.id, newUser.roles)
+        then(authService).should().issueAccessToken(newUser)
+        then(authService).should().issueRefreshToken(newUser)
         verifyEveryMocksShouldHaveNoMoreInteractions()
         assertThat(result.isNew).isTrue()
         assertThat(result.accessToken).isEqualTo(expectedAccessTokenResult)
@@ -82,8 +82,8 @@ class AppleLoginUseCaseTest {
         given(userService.createNewUser(LoginType.APPLE, appleUid))
             .willThrow(UserSocialLoginUidDuplicationException::class.java)
         given(userService.getUserBySocialLoginUid(appleUid)).willReturn(user)
-        given(jwtManager.createAccessToken(user.id, user.roles)).willReturn(expectedAccessTokenResult)
-        given(jwtManager.createRefreshToken(user.id, user.roles)).willReturn(expectedRefreshTokenResult)
+        given(authService.issueAccessToken(user)).willReturn(expectedAccessTokenResult)
+        given(authService.issueRefreshToken(user)).willReturn(expectedRefreshTokenResult)
 
         // when
         val result = sut.invoke(AppleLoginCommand(appleIdToken))
@@ -92,8 +92,8 @@ class AppleLoginUseCaseTest {
         then(authService).should().getUserInfo(LoginType.APPLE, appleIdToken)
         then(userService).should().createNewUser(LoginType.APPLE, appleUid)
         then(userService).should().getUserBySocialLoginUid(appleUid)
-        then(jwtManager).should().createAccessToken(user.id, user.roles)
-        then(jwtManager).should().createRefreshToken(user.id, user.roles)
+        then(authService).should().issueAccessToken(user)
+        then(authService).should().issueRefreshToken(user)
         verifyEveryMocksShouldHaveNoMoreInteractions()
         assertThat(result.isNew).isFalse()
         assertThat(result.accessToken).isEqualTo(expectedAccessTokenResult)

--- a/src/test/kotlin/com/routebox/routebox/application/auth/KakaoLoginUseCaseTest.kt
+++ b/src/test/kotlin/com/routebox/routebox/application/auth/KakaoLoginUseCaseTest.kt
@@ -48,8 +48,8 @@ class KakaoLoginUseCaseTest {
         given(authService.getUserInfo(LoginType.KAKAO, kakaoAccessToken))
             .willReturn(OAuthUserInfo(uid = kakaoUid))
         given(userService.createNewUser(LoginType.KAKAO, kakaoUid)).willReturn(newUser)
-        given(jwtManager.createAccessToken(newUser.id, newUser.roles)).willReturn(expectedAccessTokenResult)
-        given(jwtManager.createRefreshToken(newUser.id, newUser.roles)).willReturn(expectedRefreshTokenResult)
+        given(authService.issueAccessToken(newUser)).willReturn(expectedAccessTokenResult)
+        given(authService.issueRefreshToken(newUser)).willReturn(expectedRefreshTokenResult)
 
         // when
         val result = sut.invoke(KakaoLoginCommand(kakaoAccessToken))
@@ -57,8 +57,8 @@ class KakaoLoginUseCaseTest {
         // then
         then(authService).should().getUserInfo(LoginType.KAKAO, kakaoAccessToken)
         then(userService).should().createNewUser(LoginType.KAKAO, kakaoUid)
-        then(jwtManager).should().createAccessToken(newUser.id, newUser.roles)
-        then(jwtManager).should().createRefreshToken(newUser.id, newUser.roles)
+        then(authService).should().issueAccessToken(newUser)
+        then(authService).should().issueRefreshToken(newUser)
         verifyEveryMocksShouldHaveNoMoreInteractions()
         assertThat(result.isNew).isTrue()
         assertThat(result.accessToken).isEqualTo(expectedAccessTokenResult)
@@ -82,8 +82,8 @@ class KakaoLoginUseCaseTest {
         given(userService.createNewUser(LoginType.KAKAO, kakaoUid))
             .willThrow(UserSocialLoginUidDuplicationException::class.java)
         given(userService.getUserBySocialLoginUid(kakaoUid)).willReturn(user)
-        given(jwtManager.createAccessToken(user.id, user.roles)).willReturn(expectedAccessTokenResult)
-        given(jwtManager.createRefreshToken(user.id, user.roles)).willReturn(expectedRefreshTokenResult)
+        given(authService.issueAccessToken(user)).willReturn(expectedAccessTokenResult)
+        given(authService.issueRefreshToken(user)).willReturn(expectedRefreshTokenResult)
 
         // when
         val result = sut.invoke(KakaoLoginCommand(kakaoAccessToken))
@@ -92,8 +92,8 @@ class KakaoLoginUseCaseTest {
         then(authService).should().getUserInfo(LoginType.KAKAO, kakaoAccessToken)
         then(userService).should().createNewUser(LoginType.KAKAO, kakaoUid)
         then(userService).should().getUserBySocialLoginUid(kakaoUid)
-        then(jwtManager).should().createAccessToken(user.id, user.roles)
-        then(jwtManager).should().createRefreshToken(user.id, user.roles)
+        then(authService).should().issueAccessToken(user)
+        then(authService).should().issueRefreshToken(user)
         verifyEveryMocksShouldHaveNoMoreInteractions()
         assertThat(result.isNew).isFalse()
         assertThat(result.accessToken).isEqualTo(expectedAccessTokenResult)

--- a/src/test/kotlin/com/routebox/routebox/application/auth/RefreshTokensUseCaseTest.kt
+++ b/src/test/kotlin/com/routebox/routebox/application/auth/RefreshTokensUseCaseTest.kt
@@ -1,0 +1,119 @@
+package com.routebox.routebox.application.auth
+
+import com.routebox.routebox.domain.auth.AuthService
+import com.routebox.routebox.domain.user.User
+import com.routebox.routebox.domain.user.UserService
+import com.routebox.routebox.domain.user.constant.Gender
+import com.routebox.routebox.domain.user.constant.LoginType
+import com.routebox.routebox.exception.security.InvalidTokenException
+import com.routebox.routebox.security.JwtInfo
+import com.routebox.routebox.security.JwtManager
+import org.apache.commons.lang3.RandomStringUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.given
+import org.mockito.kotlin.then
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlin.random.Random
+import kotlin.test.Test
+
+@ExtendWith(MockitoExtension::class)
+class RefreshTokensUseCaseTest {
+    @InjectMocks
+    private lateinit var sut: RefreshTokensUseCase
+
+    @Mock
+    private lateinit var userService: UserService
+
+    @Mock
+    private lateinit var authService: AuthService
+
+    @Mock
+    private lateinit var jwtManager: JwtManager
+
+    @Test
+    fun `refresh token이 주어지고, 주어진 refresh token으로 새로운 access token과 refresh token을 발급한다`() {
+        // given
+        val refreshToken = RandomStringUtils.random(30)
+        val userId = Random.nextLong()
+        val user = createUser(userId)
+        val expectedAccessTokenResult = JwtInfo(token = RandomStringUtils.random(10), expiresAt = LocalDateTime.now())
+        val expectedRefreshTokenResult = JwtInfo(token = RandomStringUtils.random(10), expiresAt = LocalDateTime.now())
+        given(jwtManager.getUserIdFromToken(refreshToken)).willReturn(userId)
+        given(authService.findAvailableRefreshToken(userId)).willReturn(refreshToken)
+        given(userService.getUserById(userId)).willReturn(user)
+        given(authService.issueAccessToken(user)).willReturn(expectedAccessTokenResult)
+        given(authService.issueRefreshToken(user)).willReturn(expectedRefreshTokenResult)
+
+        // when
+        val (actualAccessTokenResult, actualRefreshTokenResult) = sut.invoke(refreshToken)
+
+        // then
+        then(jwtManager).should().getUserIdFromToken(refreshToken)
+        then(authService).should().findAvailableRefreshToken(userId)
+        then(userService).should().getUserById(userId)
+        then(authService).should().issueAccessToken(user)
+        then(authService).should().issueRefreshToken(user)
+        then(userService).shouldHaveNoMoreInteractions()
+        then(authService).shouldHaveNoMoreInteractions()
+        then(jwtManager).shouldHaveNoMoreInteractions()
+        assertThat(actualAccessTokenResult).isEqualTo(expectedAccessTokenResult)
+        assertThat(actualRefreshTokenResult).isEqualTo(expectedRefreshTokenResult)
+    }
+
+    @Test
+    fun `refresh token이 주어지고, 주어진 refresh token으로 새로운 access token과 refresh token을 발급한다, 만약 이용 가능한 refresh token이 없다면 예외가 발생한다`() {
+        // given
+        val refreshToken = RandomStringUtils.random(30)
+        val userId = Random.nextLong()
+        given(jwtManager.getUserIdFromToken(refreshToken)).willReturn(userId)
+        given(authService.findAvailableRefreshToken(userId)).willReturn(null)
+
+        // when
+        val ex = catchThrowable { sut.invoke(refreshToken) }
+
+        // then
+        then(jwtManager).should().getUserIdFromToken(refreshToken)
+        then(authService).should().findAvailableRefreshToken(userId)
+        then(userService).shouldHaveNoInteractions()
+        then(authService).shouldHaveNoMoreInteractions()
+        then(jwtManager).shouldHaveNoMoreInteractions()
+        assertThat(ex).isInstanceOf(InvalidTokenException::class.java)
+    }
+
+    @Test
+    fun `refresh token이 주어지고, 주어진 refresh token으로 새로운 access token과 refresh token을 발급한다, 만약 주어진 refresh token과 이용 가능한 refresh token이 다르다면 예외가 발생한다`() {
+        // given
+        val refreshToken = RandomStringUtils.random(30)
+        val availableRefreshToken = RandomStringUtils.random(40)
+        val userId = Random.nextLong()
+        given(jwtManager.getUserIdFromToken(refreshToken)).willReturn(userId)
+        given(authService.findAvailableRefreshToken(userId)).willReturn(availableRefreshToken)
+
+        // when
+        val ex = catchThrowable { sut.invoke(refreshToken) }
+
+        // then
+        then(jwtManager).should().getUserIdFromToken(refreshToken)
+        then(authService).should().findAvailableRefreshToken(userId)
+        then(userService).shouldHaveNoInteractions()
+        then(authService).shouldHaveNoMoreInteractions()
+        then(jwtManager).shouldHaveNoMoreInteractions()
+        assertThat(ex).isInstanceOf(InvalidTokenException::class.java)
+    }
+
+    private fun createUser(userId: Long): User =
+        User(
+            id = userId,
+            loginType = LoginType.KAKAO,
+            socialLoginUid = RandomStringUtils.random(10),
+            nickname = RandomStringUtils.random(5),
+            gender = Gender.PRIVATE,
+            birthDay = LocalDate.of(2024, 1, 1),
+        )
+}

--- a/src/test/kotlin/com/routebox/routebox/domain/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/routebox/routebox/domain/auth/AuthServiceTest.kt
@@ -127,6 +127,39 @@ class AuthServiceTest {
     }
 
     @Test
+    fun `유저 id가 주어지고, 주어진 유저 id에 해당하는 이용 가능한 refresh token을 조회한다`() {
+        // given
+        val userId = Random.nextLong()
+        val expectedResult = RandomStringUtils.random(10)
+        given(refreshTokenRepository.findRefreshToken(userId))
+            .willReturn(RefreshToken(userId = userId, token = expectedResult))
+
+        // when
+        val actualResult = sut.findAvailableRefreshToken(userId)
+
+        // then
+        then(refreshTokenRepository).should().findRefreshToken(userId)
+        verifyEveryMocksShouldHaveNoMoreInteractions()
+        assertThat(actualResult).isEqualTo(expectedResult)
+    }
+
+    @Test
+    fun `유저 id가 주어지고, 주어진 유저 id에 해당하는 이용 가능한 refresh token을 조회한다, 만약 이용 가능한 refresh token이 없다면 null이 반환된다`() {
+        // given
+        val userId = Random.nextLong()
+        val expectedResult = null
+        given(refreshTokenRepository.findRefreshToken(userId)).willReturn(expectedResult)
+
+        // when
+        val actualResult = sut.findAvailableRefreshToken(userId)
+
+        // then
+        then(refreshTokenRepository).should().findRefreshToken(userId)
+        verifyEveryMocksShouldHaveNoMoreInteractions()
+        assertThat(actualResult).isEqualTo(expectedResult)
+    }
+
+    @Test
     fun `유저 정보가 주어지고, 주어진 유저 정보로 access token을 발급한다`() {
         // given
         val user = createUser()

--- a/src/test/kotlin/com/routebox/routebox/domain/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/routebox/routebox/domain/user/UserServiceTest.kt
@@ -235,8 +235,8 @@ class UserServiceTest {
     private fun createUser(id: Long) = User(
         id = id,
         loginType = LoginType.KAKAO,
-        socialLoginUid = Random.toString(),
-        nickname = Random.toString(),
+        socialLoginUid = RandomStringUtils.random(10),
+        nickname = RandomStringUtils.random(5),
         gender = Gender.PRIVATE,
         birthDay = LocalDate.of(2024, 1, 1),
     )


### PR DESCRIPTION
Closed #19 

- 로그인 API 로직 중 refresh token 발행 시 redis에 저장하는 로직 추가
- Access, refresh token 재발급 API 구현