### PR TITLE
카카오/애플 로그인이 되지 않는 문제 수정 (Transaction silently rolled back because it has been marked as rollback-only)

### DIFF
--- a/src/main/kotlin/com/routebox/routebox/domain/user/UserService.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/user/UserService.kt
@@ -28,12 +28,11 @@ class UserService(private val userRepository: UserRepository) {
      * Social login uid로 유저를 조회한다.
      *
      * @param socialLoginUid 조회할 유저의 social login uid
-     * @return 조회된 user entity
-     * @throws UserNotFoundException 주어진 social login uid와 일치하는 유저가 없는 경우
+     * @return 조회된 user entity (nullable)
      */
     @Transactional(readOnly = true)
-    fun getUserBySocialLoginUid(socialLoginUid: String): User =
-        userRepository.findBySocialLoginUid(socialLoginUid) ?: throw UserNotFoundException()
+    fun findUserBySocialLoginUid(socialLoginUid: String): User? =
+        userRepository.findBySocialLoginUid(socialLoginUid)
 
     /**
      * 닉네임이 이용 가능한지 조회한다.


### PR DESCRIPTION
Closed #24 

- 문제가 되는 `KakaoLoginUseCase.invoke()`와 `AppleLoginUseCase.invoke()`의 로직을 수정함으로써 기존 transaction에 참여하는 하위 transaction에서 의도치 않은 rollback이 발생하지 않게끔 수정하였음.