### PR TITLE
유저 프로필 정보 조회 API - 응답 데이터에 내가 작성한 루트 개수 추가

### DIFF
--- a/src/main/kotlin/com/routebox/routebox/application/user/GetUserProfileUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/user/GetUserProfileUseCase.kt
@@ -1,16 +1,20 @@
 package com.routebox.routebox.application.user
 
 import com.routebox.routebox.application.user.dto.GetUserProfileResult
+import com.routebox.routebox.domain.route.RouteService
 import com.routebox.routebox.domain.user.UserService
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
 @Component
-class GetUserProfileUseCase(private val userService: UserService) {
-
+class GetUserProfileUseCase(
+    private val userService: UserService,
+    private val routeService: RouteService,
+) {
     @Transactional(readOnly = true)
     operator fun invoke(userId: Long): GetUserProfileResult {
         val user = userService.getUserById(userId)
-        return GetUserProfileResult.from(user)
+        val numOfRoutes = routeService.countRoutesByUserId(userId)
+        return GetUserProfileResult.from(user, numOfRoutes)
     }
 }

--- a/src/main/kotlin/com/routebox/routebox/application/user/dto/GetUserProfileResult.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/user/dto/GetUserProfileResult.kt
@@ -2,36 +2,33 @@ package com.routebox.routebox.application.user.dto
 
 import com.routebox.routebox.domain.user.User
 import com.routebox.routebox.domain.user.constant.Gender
-import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
 data class GetUserProfileResult(
-    @Schema(description = "Id(PK) of user", example = "1")
     val id: Long,
-
-    @Schema(description = "유저 프로필 이미지(url)", example = "https://user-profile-image")
     val profileImageUrl: String,
-
-    @Schema(description = "닉네임", example = "고작가")
     val nickname: String,
-
-    @Schema(description = "성별")
     val gender: Gender,
-
-    @Schema(description = "생일")
     val birthDay: LocalDate,
-
-    @Schema(description = "한 줄 소개", example = "평범한 일상 속의 예술을 찾고 있습니다...")
     val introduction: String,
+    val numOfRoutes: Int,
+
+    val mostVisitedLocation: String,
+    val mostTaggedRouteStyles: String,
 ) {
     companion object {
-        fun from(user: User) = GetUserProfileResult(
+        fun from(user: User, numOfRoutes: Int) = GetUserProfileResult(
             id = user.id,
             profileImageUrl = user.profileImageUrl,
             nickname = user.nickname,
             gender = user.gender,
             birthDay = user.birthDay,
             introduction = user.introduction,
+            numOfRoutes = numOfRoutes,
+
+            // TODO: 기획 문의, 루트 쪽 관련 코드 구현 필요. 기획 문의 및 루트 구현 완료 후 구현 예정
+            mostVisitedLocation = "경주",
+            mostTaggedRouteStyles = "가족여행",
         )
     }
 }

--- a/src/main/kotlin/com/routebox/routebox/controller/user/UserController.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/user/UserController.kt
@@ -17,7 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.springdoc.core.annotations.ParameterObject
+import org.springframework.http.MediaType
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -45,14 +45,7 @@ class UserController(
     @GetMapping("/v1/users/me/profile")
     fun getMyProfile(@AuthenticationPrincipal principal: UserPrincipal): UserProfileResponse {
         val myProfile = getUserProfileUseCase(userId = principal.userId)
-        return UserProfileResponse(
-            id = myProfile.id,
-            profileImageUrl = myProfile.profileImageUrl,
-            nickname = myProfile.nickname,
-            gender = myProfile.gender,
-            birthDay = myProfile.birthDay,
-            introduction = myProfile.introduction,
-        )
+        return UserProfileResponse.fromResult(myProfile)
     }
 
     @Operation(
@@ -66,14 +59,7 @@ class UserController(
         @Parameter(description = "프로필 정보를 조회할 유저의 id", example = "5") @PathVariable userId: Long,
     ): UserProfileResponse {
         val userProfile = getUserProfileUseCase(userId)
-        return UserProfileResponse(
-            id = userProfile.id,
-            profileImageUrl = userProfile.profileImageUrl,
-            nickname = userProfile.nickname,
-            gender = userProfile.gender,
-            birthDay = userProfile.birthDay,
-            introduction = userProfile.introduction,
-        )
+        return UserProfileResponse.fromResult(userProfile)
     }
 
     @Operation(
@@ -102,12 +88,12 @@ class UserController(
         ApiResponse(responseCode = "200"),
         ApiResponse(responseCode = "409", description = "[3002] 변경하려고 하는 닉네임이 이미 사용중인 경우", content = [Content()]),
     )
-    @PatchMapping("/v1/users/me")
+    @PatchMapping("/v1/users/me", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun updateUserInfo(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
-        @ParameterObject @ModelAttribute @Valid request: UpdateUserInfoRequest,
+        @ModelAttribute @Valid request: UpdateUserInfoRequest,
     ): UserResponse {
-        val updateUserInfo = updateUserInfoUseCase(request.toCommand(userId = userPrincipal.userId))
+        val updateUserInfo = updateUserInfoUseCase(request.toCommand(userPrincipal.userId))
         return UserResponse.from(updateUserInfo)
     }
 }

--- a/src/main/kotlin/com/routebox/routebox/controller/user/dto/UserProfileResponse.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/user/dto/UserProfileResponse.kt
@@ -1,12 +1,11 @@
 package com.routebox.routebox.controller.user.dto
 
+import com.routebox.routebox.application.user.dto.GetUserProfileResult
 import com.routebox.routebox.domain.user.constant.Gender
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
 data class UserProfileResponse(
-    // TODO: 내 루트 개수, 취향 정보 추가 필요
-
     @Schema(description = "Id(PK) of user", example = "1")
     val id: Long,
 
@@ -24,4 +23,28 @@ data class UserProfileResponse(
 
     @Schema(description = "한 줄 소개", example = "평범한 일상 속의 예술을 찾고 있습니다...")
     val introduction: String,
-)
+
+    @Schema(description = "작성한 루트 개수", example = "3")
+    val numOfRoutes: Int,
+
+    @Schema(description = "(취향 정보) 가장 많이 방문한 지역", example = "경주")
+    val mostVisitedLocation: String,
+
+    @Schema(description = "(취향 정보) 가장 많이 태그한 루트 스타일", example = "가족여행")
+    val mostTaggedRouteStyles: String,
+) {
+    companion object {
+        fun fromResult(getUserProfileResult: GetUserProfileResult) =
+            UserProfileResponse(
+                id = getUserProfileResult.id,
+                profileImageUrl = getUserProfileResult.profileImageUrl,
+                nickname = getUserProfileResult.nickname,
+                gender = getUserProfileResult.gender,
+                birthDay = getUserProfileResult.birthDay,
+                introduction = getUserProfileResult.introduction,
+                numOfRoutes = getUserProfileResult.numOfRoutes,
+                mostVisitedLocation = getUserProfileResult.mostVisitedLocation,
+                mostTaggedRouteStyles = getUserProfileResult.mostTaggedRouteStyles,
+            )
+    }
+}

--- a/src/main/kotlin/com/routebox/routebox/domain/route/Route.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/route/Route.kt
@@ -20,6 +20,7 @@ import java.time.LocalDateTime
 @Entity
 class Route(
     id: Long = 0,
+    user: User,
     name: String?,
     description: String?,
     startTime: LocalDateTime,
@@ -30,7 +31,6 @@ class Route(
     style: Array<String>,
     transportation: Array<String>,
     isPublic: Boolean = false,
-    user: User? = null,
 ) : TimeTrackedBaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,32 +39,43 @@ class Route(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    val user: User? = user
+    val user: User = user
 
     var name: String? = name
+        private set
 
     var description: String? = description
+        private set
 
     var startTime: LocalDateTime = startTime
+        private set
 
     var endTime: LocalDateTime = endTime
+        private set
 
     var whoWith: String? = whoWith
+        private set
 
     var numberOfPeople: Int? = numberOfPeople
+        private set
 
     var numberOfDays: String? = numberOfDays
+        private set
 
     @Convert(converter = StringArrayConverter::class)
     @Column(columnDefinition = "json")
     var style: Array<String> = style
+        private set
 
     @Convert(converter = StringArrayConverter::class)
     @Column(columnDefinition = "json")
     var transportation: Array<String> = transportation
+        private set
 
     var isPublic: Boolean = isPublic
+        private set
 
     @OneToMany(mappedBy = "route")
     var routePoints: List<RoutePoint> = mutableListOf()
+        private set
 }

--- a/src/main/kotlin/com/routebox/routebox/domain/route/RouteService.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/route/RouteService.kt
@@ -5,10 +5,14 @@ import com.routebox.routebox.infrastructure.route.RoutePointRepository
 import com.routebox.routebox.infrastructure.route.RouteRepository
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 @Service
-class RouteService(private val routeRepository: RouteRepository, private val routePointRepository: RoutePointRepository) {
+class RouteService(
+    private val routeRepository: RouteRepository,
+    private val routePointRepository: RoutePointRepository,
+) {
     /**
      * 루트 탐색 - 최신순 루트 조회
      */
@@ -20,7 +24,18 @@ class RouteService(private val routeRepository: RouteRepository, private val rou
     /**
      * 루트 상세 조회
      */
-    fun getRouteById(id: Long): Route? = routeRepository.findById(id).orElse(null)
+    fun getRouteById(id: Long): Route? =
+        routeRepository.findById(id).orElse(null)
+
+    /**
+     * 유저 id로 유저가 작성한 루트 개수 조회하기
+     *
+     * @param userId id of user
+     * @return userId에 해당하는 유저가 작성한 루트 개수
+     */
+    @Transactional(readOnly = true)
+    fun countRoutesByUserId(userId: Long) =
+        routeRepository.countByUser_Id(userId)
 
     /**
      * 루트 생성

--- a/src/main/kotlin/com/routebox/routebox/infrastructure/route/RouteRepository.kt
+++ b/src/main/kotlin/com/routebox/routebox/infrastructure/route/RouteRepository.kt
@@ -6,7 +6,10 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
+@Suppress("ktlint:standard:function-naming")
 @Repository
 interface RouteRepository : JpaRepository<Route, Long> {
     fun findAllByOrderByCreatedAtDesc(pageable: Pageable): Page<Route>
+
+    fun countByUser_Id(userId: Long): Int
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -7,6 +7,7 @@ DROP TABLE IF EXISTS user_profile_image;
 DROP TABLE IF EXISTS user_point_history;
 DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS routes;
+DROP TABLE IF EXISTS route_points;
 
 CREATE TABLE users
 (
@@ -131,21 +132,21 @@ CREATE TABLE routes
     number_of_days   VARCHAR(255),
     style            JSON,
     transportation   JSON,
-    is_public        BOOLEAN      NOT NULL DEFAULT FALSE,
-    created_at       TIMESTAMP    NOT NULL,
-    updated_at       TIMESTAMP    NOT NULL,
+    is_public        BOOLEAN  NOT NULL DEFAULT FALSE,
+    created_at       DATETIME NOT NULL,
+    updated_at       DATETIME NOT NULL,
     PRIMARY KEY (route_id)
 );
 CREATE INDEX idx__routes__user_id ON routes (user_id);
 
-CREATE TABLE route_points (
-                              point_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                              route_id BIGINT NOT NULL,
-                              latitude VARCHAR(255) NOT NULL,
-                              longitude VARCHAR(255) NOT NULL,
-                              point_order INT NOT NULL,
-                              created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                              updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
-                              FOREIGN KEY (route_id) REFERENCES routes(route_id)
+CREATE TABLE route_points
+(
+    point_id    BIGINT AUTO_INCREMENT PRIMARY KEY,
+    route_id    BIGINT       NOT NULL,
+    latitude    VARCHAR(255) NOT NULL,
+    longitude   VARCHAR(255) NOT NULL,
+    point_order INT          NOT NULL,
+    created_at  DATETIME     NOT NULL,
+    updated_at  DATETIME     NOT NULL
 );
-
+CREATE INDEX idx__route_points__route_id ON routes (route_id);

--- a/src/test/kotlin/com/routebox/routebox/application/user/GetUserProfileUseCaseTest.kt
+++ b/src/test/kotlin/com/routebox/routebox/application/user/GetUserProfileUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.routebox.routebox.application.user
 
+import com.routebox.routebox.domain.route.RouteService
 import com.routebox.routebox.domain.user.User
 import com.routebox.routebox.domain.user.UserService
 import com.routebox.routebox.domain.user.constant.Gender
@@ -25,26 +26,36 @@ class GetUserProfileUseCaseTest {
     @Mock
     lateinit var userService: UserService
 
+    @Mock
+    lateinit var routeService: RouteService
+
     @Test
     fun `유저 프로필 정보를 조회한다`() {
         // given
         val userId = Random.nextLong()
-        val expectedResult = createUser(id = userId)
-        given(userService.getUserById(userId)).willReturn(expectedResult)
+        val expectedUser = createUser(id = userId)
+        val expectedNumOfRoutes = Random.nextInt()
+        given(userService.getUserById(userId)).willReturn(expectedUser)
+        given(routeService.countRoutesByUserId(userId)).willReturn(expectedNumOfRoutes)
 
         // when
         val actualResult = sut.invoke(userId)
 
         // then
         then(userService).should().getUserById(userId)
+        then(routeService).should().countRoutesByUserId(userId)
         then(userService).shouldHaveNoMoreInteractions()
+        then(routeService).shouldHaveNoMoreInteractions()
         assertThat(actualResult)
-            .hasFieldOrPropertyWithValue("id", expectedResult.id)
-            .hasFieldOrPropertyWithValue("profileImageUrl", expectedResult.profileImageUrl)
-            .hasFieldOrPropertyWithValue("nickname", expectedResult.nickname)
-            .hasFieldOrPropertyWithValue("gender", expectedResult.gender)
-            .hasFieldOrPropertyWithValue("birthDay", expectedResult.birthDay)
-            .hasFieldOrPropertyWithValue("introduction", expectedResult.introduction)
+            .hasFieldOrPropertyWithValue("id", expectedUser.id)
+            .hasFieldOrPropertyWithValue("profileImageUrl", expectedUser.profileImageUrl)
+            .hasFieldOrPropertyWithValue("nickname", expectedUser.nickname)
+            .hasFieldOrPropertyWithValue("gender", expectedUser.gender)
+            .hasFieldOrPropertyWithValue("birthDay", expectedUser.birthDay)
+            .hasFieldOrPropertyWithValue("introduction", expectedUser.introduction)
+            .hasFieldOrPropertyWithValue("numOfRoutes", expectedNumOfRoutes)
+            .hasFieldOrProperty("mostVisitedLocation")
+            .hasFieldOrProperty("mostTaggedRouteStyles")
     }
 
     private fun createUser(id: Long) = User(

--- a/src/test/kotlin/com/routebox/routebox/controller/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/routebox/routebox/controller/user/UserControllerTest.kt
@@ -53,6 +53,9 @@ class UserControllerTest @Autowired constructor(private val mvc: MockMvc) {
             gender = Gender.PRIVATE,
             birthDay = LocalDate.of(2024, 1, 1),
             introduction = "I am...",
+            numOfRoutes = Random.nextInt(),
+            mostVisitedLocation = RandomStringUtils.random(10),
+            mostTaggedRouteStyles = RandomStringUtils.random(10),
         )
         given(getUserProfileUseCase.invoke(userId)).willReturn(expectedResult)
 
@@ -67,6 +70,9 @@ class UserControllerTest @Autowired constructor(private val mvc: MockMvc) {
             .andExpect(jsonPath("$.gender").value(expectedResult.gender.toString()))
             .andExpect(jsonPath("$.birthDay").value(expectedResult.birthDay.toString()))
             .andExpect(jsonPath("$.introduction").value(expectedResult.introduction))
+            .andExpect(jsonPath("$.numOfRoutes").value(expectedResult.numOfRoutes))
+            .andExpect(jsonPath("$.mostVisitedLocation").value(expectedResult.mostVisitedLocation))
+            .andExpect(jsonPath("$.mostTaggedRouteStyles").value(expectedResult.mostTaggedRouteStyles))
         then(getUserProfileUseCase).should().invoke(userId)
         then(getUserProfileUseCase).shouldHaveNoMoreInteractions()
     }
@@ -82,6 +88,9 @@ class UserControllerTest @Autowired constructor(private val mvc: MockMvc) {
             gender = Gender.PRIVATE,
             birthDay = LocalDate.of(2024, 1, 1),
             introduction = "I am...",
+            numOfRoutes = Random.nextInt(),
+            mostVisitedLocation = RandomStringUtils.random(10),
+            mostTaggedRouteStyles = RandomStringUtils.random(10),
         )
         given(getUserProfileUseCase.invoke(targetUserId)).willReturn(expectedResult)
 
@@ -96,6 +105,9 @@ class UserControllerTest @Autowired constructor(private val mvc: MockMvc) {
             .andExpect(jsonPath("$.gender").value(expectedResult.gender.toString()))
             .andExpect(jsonPath("$.birthDay").value(expectedResult.birthDay.toString()))
             .andExpect(jsonPath("$.introduction").value(expectedResult.introduction))
+            .andExpect(jsonPath("$.numOfRoutes").value(expectedResult.numOfRoutes))
+            .andExpect(jsonPath("$.mostVisitedLocation").value(expectedResult.mostVisitedLocation))
+            .andExpect(jsonPath("$.mostTaggedRouteStyles").value(expectedResult.mostTaggedRouteStyles))
         then(getUserProfileUseCase).should().invoke(targetUserId)
         then(getUserProfileUseCase).shouldHaveNoMoreInteractions()
     }


### PR DESCRIPTION
Closed #51

- '내 프로필 정보 조회 API' 응답 데이터에 내가 작성한 루트 개수 추가
- '유저 프로필 정보 조회 API' 응답 데이터에 내가 작성한 루트 개수 추가
- 응답 데이터에 취향 정보 mock-up 데이터로 추가
