### PR TITLE
루트 상세 조회 API 응답 데이터에 공개 여부(`isPublic`) 추가

### DIFF
--- a/src/main/kotlin/com/routebox/routebox/application/route/dto/GetRouteDetailWithActivitiesResult.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/route/dto/GetRouteDetailWithActivitiesResult.kt
@@ -16,6 +16,7 @@ data class GetRouteDetailWithActivitiesResult(
     val numberOfPeople: Int?,
     val numberOfDays: String?,
     val transportation: String?,
+    val isPublic: Boolean,
     val createdAt: String,
     val routePath: List<Map<String, String>>,
     val routeActivities: List<ActivityResult>,
@@ -24,8 +25,8 @@ data class GetRouteDetailWithActivitiesResult(
         fun from(
             route: Route,
         ): GetRouteDetailWithActivitiesResult = GetRouteDetailWithActivitiesResult(
-            routeId = route.id!!,
-            userId = route.user.id!!,
+            routeId = route.id,
+            userId = route.user.id,
             profileImageUrl = route.user.profileImageUrl,
             nickname = route.user.nickname,
             routeName = route.name,
@@ -37,6 +38,7 @@ data class GetRouteDetailWithActivitiesResult(
             numberOfPeople = route.numberOfPeople,
             numberOfDays = route.numberOfDays,
             transportation = route.transportations,
+            isPublic = route.isPublic,
             createdAt = route.createdAt.toString(),
             routePath = route.routePoints.map { mapOf("latitude" to it.latitude, "longitude" to it.longitude) },
             routeActivities = route.routeActivities.map { ActivityResult.from(it) },

--- a/src/main/kotlin/com/routebox/routebox/controller/route/RouteController.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/route/RouteController.kt
@@ -54,8 +54,8 @@ class RouteController(
     }
 
     @Operation(
-        summary = "루트 상세 조회",
-        description = "루트 상세정보 조회",
+        summary = "루트 단건 조회",
+        description = "루트 단건 조회",
     )
     @ApiResponses(
         ApiResponse(responseCode = "200"),

--- a/src/main/kotlin/com/routebox/routebox/controller/route/dto/RouteDetailResponse.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/route/dto/RouteDetailResponse.kt
@@ -44,6 +44,9 @@ data class RouteDetailResponse(
     @Schema(description = "교통수단")
     val transportation: String?,
 
+    @Schema(description = "공개 여부")
+    val isPublic: Boolean,
+
     @Schema(description = "루트 생성일", example = "2021-08-01T00:00:00")
     val createdAt: LocalDateTime,
 
@@ -54,25 +57,24 @@ data class RouteDetailResponse(
     val routeActivities: List<RouteActivityResponse>,
 ) {
     companion object {
-        fun from(
-            getRouteDetailWithActivitiesResult: GetRouteDetailWithActivitiesResult,
-        ): RouteDetailResponse = RouteDetailResponse(
-            routeId = getRouteDetailWithActivitiesResult.routeId,
-            userId = getRouteDetailWithActivitiesResult.userId,
-            profileImageUrl = getRouteDetailWithActivitiesResult.profileImageUrl,
-            nickname = getRouteDetailWithActivitiesResult.nickname,
-            routeName = getRouteDetailWithActivitiesResult.routeName,
-            routeDescription = getRouteDetailWithActivitiesResult.routeDescription,
-            startTime = LocalDateTime.parse(getRouteDetailWithActivitiesResult.startTime),
-            endTime = LocalDateTime.parse(getRouteDetailWithActivitiesResult.endTime),
-            whoWith = getRouteDetailWithActivitiesResult.whoWith,
-            routeStyles = getRouteDetailWithActivitiesResult.routeStyles,
-            numberOfPeople = getRouteDetailWithActivitiesResult.numberOfPeople,
-            numberOfDays = getRouteDetailWithActivitiesResult.numberOfDays,
-            transportation = getRouteDetailWithActivitiesResult.transportation,
-            createdAt = LocalDateTime.parse(getRouteDetailWithActivitiesResult.createdAt),
-            routePath = getRouteDetailWithActivitiesResult.routePath,
-            routeActivities = getRouteDetailWithActivitiesResult.routeActivities.map { RouteActivityResponse.from(it) },
+        fun from(result: GetRouteDetailWithActivitiesResult): RouteDetailResponse = RouteDetailResponse(
+            routeId = result.routeId,
+            userId = result.userId,
+            profileImageUrl = result.profileImageUrl,
+            nickname = result.nickname,
+            routeName = result.routeName,
+            routeDescription = result.routeDescription,
+            startTime = LocalDateTime.parse(result.startTime),
+            endTime = LocalDateTime.parse(result.endTime),
+            whoWith = result.whoWith,
+            routeStyles = result.routeStyles,
+            numberOfPeople = result.numberOfPeople,
+            numberOfDays = result.numberOfDays,
+            transportation = result.transportation,
+            isPublic = result.isPublic,
+            createdAt = LocalDateTime.parse(result.createdAt),
+            routePath = result.routePath,
+            routeActivities = result.routeActivities.map { RouteActivityResponse.from(it) },
         )
     }
 }


### PR DESCRIPTION
Closed #61 

- 루트 상세 조회 API 응답 데이터에 공개 여부(`isPublic`) 추가