### PR TITLE
[댓글] 댓글 삭제, 내용 수정, 신고 API 구현 | 댓글 작성 API 수정

### DIFF
--- a/src/main/kotlin/com/routebox/routebox/application/comment/DeleteCommentUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/comment/DeleteCommentUseCase.kt
@@ -10,5 +10,5 @@ class DeleteCommentUseCase(
 ) {
     /*댓글 삭제*/
     @Transactional
-    operator fun invoke(id: Long) = commentService.deleteComment(id)
+    operator fun invoke(id: Long, userId: Long) = commentService.deleteComment(id, userId)
 }

--- a/src/main/kotlin/com/routebox/routebox/application/comment/DeleteCommentUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/comment/DeleteCommentUseCase.kt
@@ -1,0 +1,14 @@
+package com.routebox.routebox.application.comment
+
+import com.routebox.routebox.domain.comment.CommentService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class DeleteCommentUseCase(
+    private val commentService: CommentService,
+) {
+    /*댓글 삭제*/
+    @Transactional
+    operator fun invoke(id: Long) = commentService.deleteComment(id)
+}

--- a/src/main/kotlin/com/routebox/routebox/application/comment/ModifyCommentUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/comment/ModifyCommentUseCase.kt
@@ -10,5 +10,5 @@ class ModifyCommentUseCase(
 ) {
     /*댓글 내용 수정*/
     @Transactional
-    operator fun invoke(id: Long, content: String) = commentService.modifyComment(id, content)
+    operator fun invoke(id: Long, content: String, userId: Long) = commentService.modifyComment(id, content, userId)
 }

--- a/src/main/kotlin/com/routebox/routebox/application/comment/ModifyCommentUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/comment/ModifyCommentUseCase.kt
@@ -1,0 +1,14 @@
+package com.routebox.routebox.application.comment
+
+import com.routebox.routebox.domain.comment.CommentService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ModifyCommentUseCase(
+    private val commentService: CommentService,
+) {
+    /*댓글 내용 수정*/
+    @Transactional
+    operator fun invoke(id: Long, content: String) = commentService.modifyComment(id, content)
+}

--- a/src/main/kotlin/com/routebox/routebox/application/comment_report/ReportCommentUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/comment_report/ReportCommentUseCase.kt
@@ -1,0 +1,15 @@
+package com.routebox.routebox.application.comment_report
+
+import com.routebox.routebox.application.comment_report.dto.ReportCommentDto
+import com.routebox.routebox.domain.comment_report.CommentReportService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ReportCommentUseCase(
+    private val commentReportService: CommentReportService,
+) {
+    /*댓글 신고*/
+    @Transactional
+    operator fun invoke(dto: ReportCommentDto) = commentReportService.report(dto.reporterId, dto.reportedCommentId)
+}

--- a/src/main/kotlin/com/routebox/routebox/application/comment_report/dto/ReportCommentDto.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/comment_report/dto/ReportCommentDto.kt
@@ -1,0 +1,6 @@
+package com.routebox.routebox.application.comment_report.dto
+
+data class ReportCommentDto(
+    val reporterId: Long,
+    val reportedCommentId: Long,
+)

--- a/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
@@ -76,10 +76,11 @@ class CommentController(
     )
     @PatchMapping("/{commentId}")
     fun modifyComment(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PathVariable commentId: Long,
         @RequestBody @Valid request: PatchModifyCommentRequest,
     ): ResponseEntity<String> {
-        modifyCommentUseCase(commentId, request.content)
+        modifyCommentUseCase(commentId, request.content, userPrincipal.userId)
 
         return ResponseEntity.ok("댓글 수정을 완료했습니다.")
     }
@@ -91,9 +92,10 @@ class CommentController(
     )
     @DeleteMapping("/{commentId}")
     fun deleteComment(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PathVariable commentId: Long,
     ): ResponseEntity<String> {
-        deleteCommentUseCase(commentId)
+        deleteCommentUseCase(commentId, userPrincipal.userId)
 
         return ResponseEntity.ok("댓글을 삭제했습니다.")
     }

--- a/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
@@ -1,5 +1,6 @@
 package com.routebox.routebox.controller.comment
 
+import com.routebox.routebox.application.comment.DeleteCommentUseCase
 import com.routebox.routebox.application.comment.GetAllCommentsOfPostUseCase
 import com.routebox.routebox.application.comment.ModifyCommentUseCase
 import com.routebox.routebox.application.comment.WriteCommentUseCase
@@ -14,6 +15,7 @@ import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -30,6 +32,7 @@ class CommentController(
     private val writeCommentUseCase: WriteCommentUseCase,
     private val getAllCommentsOfPostUseCase: GetAllCommentsOfPostUseCase,
     private val modifyCommentUseCase: ModifyCommentUseCase,
+    private val deleteCommentUseCase: DeleteCommentUseCase,
 ) {
     @Operation(
         summary = "댓글 작성",
@@ -78,8 +81,22 @@ class CommentController(
         @PathVariable commentId: Long,
         @RequestBody @Valid request: PatchModifyCommentRequest,
     ): ResponseEntity<String> {
-        val updateUserInfo = modifyCommentUseCase(commentId, request.content)
+        modifyCommentUseCase(commentId, request.content)
 
         return ResponseEntity.ok("댓글 수정을 완료했습니다.")
+    }
+
+    @Operation(
+        summary = "댓글 삭제",
+        description = "댓글을 삭제합니다.",
+        security = [SecurityRequirement(name = "access-token")],
+    )
+    @DeleteMapping("/{commentId}")
+    fun deleteComment(
+        @PathVariable commentId: Long,
+    ): ResponseEntity<String> {
+        deleteCommentUseCase(commentId)
+
+        return ResponseEntity.ok("댓글을 삭제했습니다.")
     }
 }

--- a/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
@@ -36,20 +36,18 @@ class CommentController(
 ) {
     @Operation(
         summary = "댓글 작성",
-        description = "<p>게시글에 댓글을 작성합니다." +
-            "<p>댓글 내용에 <code>null</code>이나 빈 값이 들어갈 경우, 작성되지 않습니다.",
+        description = "게시글에 댓글을 작성합니다.",
         security = [SecurityRequirement(name = "access-token")],
     )
-    @PostMapping("/{routeId}")
+    @PostMapping("")
     fun writeComment(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
-        @PathVariable routeId: Long,
         @RequestBody request: PostWriteCommentRequest,
     ): ResponseEntity<String> {
         // 댓글을 작성한다
         writeCommentUseCase(
             userId = userPrincipal.userId,
-            routeId = routeId,
+            routeId = request.routeId,
             content = request.content,
         )
 

--- a/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
@@ -1,17 +1,21 @@
 package com.routebox.routebox.controller.comment
 
 import com.routebox.routebox.application.comment.GetAllCommentsOfPostUseCase
+import com.routebox.routebox.application.comment.ModifyCommentUseCase
 import com.routebox.routebox.application.comment.WriteCommentUseCase
 import com.routebox.routebox.controller.comment.dto.GetAllCommentsOfPostResponse
+import com.routebox.routebox.controller.comment.dto.PatchModifyCommentRequest
 import com.routebox.routebox.controller.comment.dto.PostWriteCommentRequest
 import com.routebox.routebox.security.UserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -25,10 +29,12 @@ import org.springframework.web.bind.annotation.RestController
 class CommentController(
     private val writeCommentUseCase: WriteCommentUseCase,
     private val getAllCommentsOfPostUseCase: GetAllCommentsOfPostUseCase,
+    private val modifyCommentUseCase: ModifyCommentUseCase,
 ) {
     @Operation(
         summary = "댓글 작성",
-        description = "게시글에 댓글을 작성합니다.",
+        description = "<p>게시글에 댓글을 작성합니다." +
+            "<p>댓글 내용에 <code>null</code>이나 빈 값이 들어갈 경우, 작성되지 않습니다.",
         security = [SecurityRequirement(name = "access-token")],
     )
     @PostMapping("/{routeId}")
@@ -60,5 +66,20 @@ class CommentController(
         // response 객체로 변환한다
         val response = GetAllCommentsOfPostResponse(comments)
         return ResponseEntity.ok(response)
+    }
+
+    @Operation(
+        summary = "댓글 내용 수정",
+        description = "댓글 내용을 수정합니다.",
+        security = [SecurityRequirement(name = "access-token")],
+    )
+    @PatchMapping("/{commentId}")
+    fun modifyComment(
+        @PathVariable commentId: Long,
+        @RequestBody @Valid request: PatchModifyCommentRequest,
+    ): ResponseEntity<String> {
+        val updateUserInfo = modifyCommentUseCase(commentId, request.content)
+
+        return ResponseEntity.ok("댓글 수정을 완료했습니다.")
     }
 }

--- a/src/main/kotlin/com/routebox/routebox/controller/comment/dto/PatchModifyCommentRequest.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/comment/dto/PatchModifyCommentRequest.kt
@@ -1,0 +1,14 @@
+package com.routebox.routebox.controller.comment.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+data class PatchModifyCommentRequest(
+    @Schema(description = "댓글 내용", example = "좋은 루트네요!!")
+    @field:NotNull
+    @field:NotBlank
+    @field:Size(min = 1, max = 500)
+    val content: String,
+)

--- a/src/main/kotlin/com/routebox/routebox/controller/comment/dto/PostWriteCommentRequest.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/comment/dto/PostWriteCommentRequest.kt
@@ -6,6 +6,9 @@ import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 
 data class PostWriteCommentRequest(
+    @Schema(description = "댓글이 달릴 루트 id", example = "1")
+    val routeId: Long,
+
     @Schema(description = "댓글 내용", example = "좋은 루트네요!!")
     @field:NotNull
     @field:NotBlank

--- a/src/main/kotlin/com/routebox/routebox/controller/report/ReportController.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/report/ReportController.kt
@@ -1,9 +1,12 @@
 package com.routebox.routebox.controller.report
 
+import com.routebox.routebox.application.comment_report.ReportCommentUseCase
+import com.routebox.routebox.application.comment_report.dto.ReportCommentDto
 import com.routebox.routebox.application.route_report.ReportRouteUseCase
 import com.routebox.routebox.application.route_report.dto.ReportRouteCommand
 import com.routebox.routebox.application.user_report.ReportUserUseCase
 import com.routebox.routebox.application.user_report.dto.ReportUserCommand
+import com.routebox.routebox.controller.report.dto.ReportCommentRequest
 import com.routebox.routebox.controller.report.dto.ReportRouteRequest
 import com.routebox.routebox.controller.report.dto.ReportRouteResponse
 import com.routebox.routebox.controller.report.dto.ReportUserRequest
@@ -12,6 +15,7 @@ import com.routebox.routebox.security.UserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -24,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController
 class ReportController(
     private val reportUserUseCase: ReportUserUseCase,
     private val reportRouteUseCase: ReportRouteUseCase,
+    private val reportCommentUseCase: ReportCommentUseCase,
 ) {
     @Operation(
         summary = "유저 신고",
@@ -63,5 +68,25 @@ class ReportController(
             ),
         )
         return ReportRouteResponse(routeReportId)
+    }
+
+    @Operation(
+        summary = "댓글 신고",
+        description = "댓글 신고하기",
+        security = [SecurityRequirement(name = "access-token")],
+    )
+    @PostMapping("/v1/reports/comment")
+    fun reportComment(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @RequestBody request: ReportCommentRequest,
+    ): ResponseEntity<String> {
+        reportCommentUseCase(
+            ReportCommentDto(
+                reporterId = userPrincipal.userId,
+                reportedCommentId = request.commentId,
+            ),
+        )
+
+        return ResponseEntity.ok("댓글을 신고했습니다")
     }
 }

--- a/src/main/kotlin/com/routebox/routebox/controller/report/dto/ReportCommentRequest.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/report/dto/ReportCommentRequest.kt
@@ -1,0 +1,8 @@
+package com.routebox.routebox.controller.report.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ReportCommentRequest(
+    @Schema(description = "신고할 댓글 id", example = "1")
+    val commentId: Long,
+)

--- a/src/main/kotlin/com/routebox/routebox/domain/comment/Comment.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/comment/Comment.kt
@@ -35,5 +35,5 @@ class Comment(
     val user: User = user
 
     @Column(nullable = false, length = 500)
-    val content: String = content.take(500)
+    var content: String = content.take(500)
 }

--- a/src/main/kotlin/com/routebox/routebox/domain/comment/CommentService.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/comment/CommentService.kt
@@ -3,6 +3,7 @@ package com.routebox.routebox.domain.comment
 import com.routebox.routebox.application.comment.dto.GetAllCommentsOfPostDto
 import com.routebox.routebox.domain.route.Route
 import com.routebox.routebox.domain.user.User
+import com.routebox.routebox.exception.comment.CommentNotFoundException
 import com.routebox.routebox.exception.route.RouteNotFoundException
 import com.routebox.routebox.exception.user.UserNotFoundException
 import com.routebox.routebox.infrastructure.comment.CommentRepository
@@ -70,5 +71,16 @@ class CommentService(
             duration.toMinutes() > 0 -> "${duration.toMinutes()}분 전"
             else -> "방금 전"
         }
+    }
+
+    /*댓글 내용 수정*/
+    @Transactional
+    fun modifyComment(id: Long, content: String) {
+        // 수정할 댓글을 조회
+        val comment: Comment = commentRepository.findById(id)
+            .orElseThrow { throw CommentNotFoundException() }
+
+        // 댓글 내용 수정
+        comment.content = content
     }
 }

--- a/src/main/kotlin/com/routebox/routebox/domain/comment/CommentService.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/comment/CommentService.kt
@@ -3,6 +3,8 @@ package com.routebox.routebox.domain.comment
 import com.routebox.routebox.application.comment.dto.GetAllCommentsOfPostDto
 import com.routebox.routebox.domain.route.Route
 import com.routebox.routebox.domain.user.User
+import com.routebox.routebox.exception.comment.CommentDeleteForbiddenException
+import com.routebox.routebox.exception.comment.CommentEditForbiddenException
 import com.routebox.routebox.exception.comment.CommentNotFoundException
 import com.routebox.routebox.exception.route.RouteNotFoundException
 import com.routebox.routebox.exception.user.UserNotFoundException
@@ -75,10 +77,18 @@ class CommentService(
 
     /*댓글 내용 수정*/
     @Transactional
-    fun modifyComment(id: Long, content: String) {
+    fun modifyComment(id: Long, content: String, userId: Long) {
         // 수정할 댓글을 조회
         val comment: Comment = commentRepository.findById(id)
             .orElseThrow { throw CommentNotFoundException() }
+
+        // 요청자 조회
+        val user: User = userRepository.findById(userId)
+            .orElseThrow { throw UserNotFoundException() }
+        // 요청자와 댓글 작성자가 다를 경우 예외 발생
+        if (comment.user.id != user.id) {
+            throw CommentEditForbiddenException()
+        }
 
         // 댓글 내용 수정
         comment.content = content
@@ -86,10 +96,18 @@ class CommentService(
 
     /*댓글 삭제*/
     @Transactional
-    fun deleteComment(id: Long) {
+    fun deleteComment(id: Long, userId: Long) {
         // 삭제할 댓글을 조회
         val comment: Comment = commentRepository.findById(id)
             .orElseThrow { throw CommentNotFoundException() }
+
+        // 요청자 조회
+        val user: User = userRepository.findById(userId)
+            .orElseThrow { throw UserNotFoundException() }
+        // 요청자와 댓글 작성자가 다를 경우 예외 발생
+        if (comment.user.id != user.id) {
+            throw CommentDeleteForbiddenException()
+        }
 
         // 댓글 삭제
         commentRepository.delete(comment)

--- a/src/main/kotlin/com/routebox/routebox/domain/comment/CommentService.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/comment/CommentService.kt
@@ -24,7 +24,7 @@ class CommentService(
     /*댓글 작성*/
     @Transactional
     fun writeComment(userId: Long, routeId: Long, content: String) {
-        // 댓글을 작성하려면 User와 Route가 존재해야 하므로 ID로 조회
+        // id에 해당하는 각 객체 조회
         val user: User = userRepository.findById(userId)
             .orElseThrow { throw UserNotFoundException() }
         val route: Route = routeRepository.findById(routeId)

--- a/src/main/kotlin/com/routebox/routebox/domain/comment/CommentService.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/comment/CommentService.kt
@@ -83,4 +83,15 @@ class CommentService(
         // 댓글 내용 수정
         comment.content = content
     }
+
+    /*댓글 삭제*/
+    @Transactional
+    fun deleteComment(id: Long) {
+        // 삭제할 댓글을 조회
+        val comment: Comment = commentRepository.findById(id)
+            .orElseThrow { throw CommentNotFoundException() }
+
+        // 댓글 삭제
+        commentRepository.delete(comment)
+    }
 }

--- a/src/main/kotlin/com/routebox/routebox/domain/comment_report/CommentReport.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/comment_report/CommentReport.kt
@@ -1,7 +1,7 @@
-package com.routebox.routebox.domain.comment
+package com.routebox.routebox.domain.comment_report
 
+import com.routebox.routebox.domain.comment.Comment
 import com.routebox.routebox.domain.common.TimeTrackedBaseEntity
-import com.routebox.routebox.domain.route.Route
 import com.routebox.routebox.domain.user.User
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -13,26 +13,22 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
-@Table(name = "comments")
+@Table(name = "comment_report")
 @Entity
-class Comment(
-    route: Route,
-    user: User,
-    content: String,
+class CommentReport(
+    reporter: User,
+    reportedComment: Comment,
 ) : TimeTrackedBaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "comment_id")
+    @Column(name = "comment_report_id")
     val id: Long = 0
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "route_id")
-    val route: Route = route
+    @JoinColumn(name = "reporter_id")
+    val reporter: User = reporter
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    val user: User = user
-
-    @Column(nullable = false, length = 500)
-    var content: String = content.take(500)
+    @JoinColumn(name = "reported_comment_id")
+    val reportedComment: Comment = reportedComment
 }

--- a/src/main/kotlin/com/routebox/routebox/domain/comment_report/CommentReportService.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/comment_report/CommentReportService.kt
@@ -3,6 +3,7 @@ package com.routebox.routebox.domain.comment_report
 import com.routebox.routebox.domain.comment.Comment
 import com.routebox.routebox.domain.user.User
 import com.routebox.routebox.exception.comment.CommentNotFoundException
+import com.routebox.routebox.exception.comment_report.CommentReportForbiddenException
 import com.routebox.routebox.exception.user.UserNotFoundException
 import com.routebox.routebox.infrastructure.comment.CommentRepository
 import com.routebox.routebox.infrastructure.comment_report.CommentReportRepository
@@ -18,15 +19,20 @@ class CommentReportService(
     /*댓글 신고*/
     fun report(reporterId: Long, reportedCommentId: Long) {
         // id에 해당하는 각 객체 조회
-        val user: User = userRepository.findById(reporterId)
+        val reporter: User = userRepository.findById(reporterId)
             .orElseThrow { throw UserNotFoundException() }
         val comment: Comment = commentRepository.findById(reportedCommentId)
             .orElseThrow { throw CommentNotFoundException() }
 
+        // 요청자가 댓글 작성자일 경우 예외 발생
+        if (comment.user.id == reporter.id) {
+            throw CommentReportForbiddenException()
+        }
+
         // 댓글 신고
         commentReportRepository.save(
             CommentReport(
-                user,
+                reporter,
                 comment,
             ),
         )

--- a/src/main/kotlin/com/routebox/routebox/domain/comment_report/CommentReportService.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/comment_report/CommentReportService.kt
@@ -1,0 +1,34 @@
+package com.routebox.routebox.domain.comment_report
+
+import com.routebox.routebox.domain.comment.Comment
+import com.routebox.routebox.domain.user.User
+import com.routebox.routebox.exception.comment.CommentNotFoundException
+import com.routebox.routebox.exception.user.UserNotFoundException
+import com.routebox.routebox.infrastructure.comment.CommentRepository
+import com.routebox.routebox.infrastructure.comment_report.CommentReportRepository
+import com.routebox.routebox.infrastructure.user.UserRepository
+import org.springframework.stereotype.Service
+
+@Service
+class CommentReportService(
+    private val commentReportRepository: CommentReportRepository,
+    private val userRepository: UserRepository,
+    private val commentRepository: CommentRepository,
+) {
+    /*댓글 신고*/
+    fun report(reporterId: Long, reportedCommentId: Long) {
+        // id에 해당하는 각 객체 조회
+        val user: User = userRepository.findById(reporterId)
+            .orElseThrow { throw UserNotFoundException() }
+        val comment: Comment = commentRepository.findById(reportedCommentId)
+            .orElseThrow { throw CommentNotFoundException() }
+
+        // 댓글 신고
+        commentReportRepository.save(
+            CommentReport(
+                user,
+                comment,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/routebox/routebox/exception/CustomExceptionType.kt
+++ b/src/main/kotlin/com/routebox/routebox/exception/CustomExceptionType.kt
@@ -53,6 +53,9 @@ enum class CustomExceptionType(
      * 댓글 관련 예외
      */
     COMMENT_NOT_FOUND(3600, "일치하는 댓글을 찾을 수 없습니다."),
+    COMMENT_EDIT_FORBIDDEN(3601, "이 댓글을 수정할 권한이 없습니다."),
+    COMMENT_DELETE_FORBIDDEN(3602, "이 댓글을 삭제할 권한이 없습니다."),
+    COMMENT_REPORT_FORBIDDEN(3602, "이 댓글을 신고할 권한이 없습니다."),
 
     /**
      * Apple 관련 예외

--- a/src/main/kotlin/com/routebox/routebox/exception/CustomExceptionType.kt
+++ b/src/main/kotlin/com/routebox/routebox/exception/CustomExceptionType.kt
@@ -8,6 +8,7 @@ package com.routebox.routebox.exception
  * - 3000 ~ 3199: 유저 관련 예외
  * - 3200 ~ 3399: 루트 관련 예외
  * - 3400 ~ 3599: 담은(구매한) 루트 관련 예외
+ * - 3600 ~ 3799: 댓글 관련 예외
  * - 10000 ~ 10199: kakao(kakao open api 등) 관련 관련 예외
  */
 enum class CustomExceptionType(
@@ -47,6 +48,11 @@ enum class CustomExceptionType(
      * Kakao(kakao open api 등) 관련 예외
      */
     REQUEST_KAKAO_USER_INFO(10000, "카카오 사용자 정보 조회 중 오류가 발생했습니다."),
+
+    /**
+     * 댓글 관련 예외
+     */
+    COMMENT_NOT_FOUND(3600, "일치하는 댓글을 찾을 수 없습니다."),
 
     /**
      * Apple 관련 예외

--- a/src/main/kotlin/com/routebox/routebox/exception/comment/CommentDeleteForbiddenException.kt
+++ b/src/main/kotlin/com/routebox/routebox/exception/comment/CommentDeleteForbiddenException.kt
@@ -1,0 +1,6 @@
+package com.routebox.routebox.exception.comment
+
+import com.routebox.routebox.exception.CustomExceptionType
+import com.routebox.routebox.exception.common.ForbiddenException
+
+class CommentDeleteForbiddenException : ForbiddenException(CustomExceptionType.COMMENT_DELETE_FORBIDDEN)

--- a/src/main/kotlin/com/routebox/routebox/exception/comment/CommentEditForbiddenException.kt
+++ b/src/main/kotlin/com/routebox/routebox/exception/comment/CommentEditForbiddenException.kt
@@ -1,0 +1,6 @@
+package com.routebox.routebox.exception.comment
+
+import com.routebox.routebox.exception.CustomExceptionType
+import com.routebox.routebox.exception.common.ForbiddenException
+
+class CommentEditForbiddenException : ForbiddenException(CustomExceptionType.COMMENT_EDIT_FORBIDDEN)

--- a/src/main/kotlin/com/routebox/routebox/exception/comment/CommentNotFoundException.kt
+++ b/src/main/kotlin/com/routebox/routebox/exception/comment/CommentNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.routebox.routebox.exception.comment
+
+import com.routebox.routebox.exception.CustomExceptionType
+import com.routebox.routebox.exception.common.NotFoundException
+
+class CommentNotFoundException : NotFoundException(CustomExceptionType.COMMENT_NOT_FOUND)

--- a/src/main/kotlin/com/routebox/routebox/exception/comment_report/CommentReportForbiddenException.kt
+++ b/src/main/kotlin/com/routebox/routebox/exception/comment_report/CommentReportForbiddenException.kt
@@ -1,0 +1,6 @@
+package com.routebox.routebox.exception.comment_report
+
+import com.routebox.routebox.exception.CustomExceptionType
+import com.routebox.routebox.exception.common.ForbiddenException
+
+class CommentReportForbiddenException : ForbiddenException(CustomExceptionType.COMMENT_REPORT_FORBIDDEN)

--- a/src/main/kotlin/com/routebox/routebox/infrastructure/comment_report/CommentReportRepository.kt
+++ b/src/main/kotlin/com/routebox/routebox/infrastructure/comment_report/CommentReportRepository.kt
@@ -1,0 +1,7 @@
+package com.routebox.routebox.infrastructure.comment_report
+
+import com.routebox.routebox.domain.comment_report.CommentReport
+import org.springframework.data.jpa.repository.JpaRepository
+
+@Suppress("ktlint:standard:function-naming")
+interface CommentReportRepository : JpaRepository<CommentReport, Long>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -237,7 +237,7 @@ CREATE TABLE route_report
 (
     route_report_id   BIGINT       NOT NULL AUTO_INCREMENT,
     reporter_id       BIGINT       NOT NULL COMMENT '신고자 id',
-    reported_route_id BIGINT       NOT NULL COMMENT '신고 대상(루트)의 id',
+    reported_route_id BIGINT       NOT NULL COMMENT '신고 대상(루트)의 id고',
     reason_types      VARCHAR(255) NOT NULL COMMENT '신고 사유',
     reason_detail     VARCHAR(255) COMMENT '신고 상세 사유',
     created_at        DATETIME     NOT NULL,
@@ -285,3 +285,13 @@ CREATE TABLE comments (
 );
 CREATE INDEX idx__comments__route_id ON comments (route_id);
 CREATE INDEX idx__comments__user_id ON comments (user_id);
+
+CREATE TABLE comment_report (
+    comment_report_id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '댓글 신고 ID',
+    reporter_id BIGINT NOT NULL COMMENT '신고자 ID',
+    reported_comment_id BIGINT NOT NULL COMMENT '신고된 댓글 ID',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 시간',
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '업데이트 시간'
+);
+-- CREATE INDEX idx__comment_report__reporter_id ON comment_report (reporter_id);
+-- CREATE INDEX idx__comment_report__reported_comment_id ON comment_report (reported_comment_id);


### PR DESCRIPTION
Closes #116 

[변경 사항]
- 댓글 삭제 API 구현
- 댓글 내용 수정 API 구현
- 댓글 신고 API 구현

각 API에 권한 검사까지 추가했습니다

- 댓글 작성 API 수정 : pathVariable로 받던 값을 body로 받도록 수정