### PR TITLE
[댓글] 응답형식 수정

### DIFF
--- a/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
@@ -4,6 +4,7 @@ import com.routebox.routebox.application.comment.DeleteCommentUseCase
 import com.routebox.routebox.application.comment.GetAllCommentsOfPostUseCase
 import com.routebox.routebox.application.comment.ModifyCommentUseCase
 import com.routebox.routebox.application.comment.WriteCommentUseCase
+import com.routebox.routebox.controller.comment.dto.DeleteCommentResponse
 import com.routebox.routebox.controller.comment.dto.GetAllCommentsOfPostResponse
 import com.routebox.routebox.controller.comment.dto.PatchModifyCommentRequest
 import com.routebox.routebox.controller.comment.dto.PatchModifyCommentResponse
@@ -113,9 +114,9 @@ class CommentController(
     fun deleteComment(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PathVariable commentId: Long,
-    ): ResponseEntity<String> {
+    ): ResponseEntity<DeleteCommentResponse> {
         deleteCommentUseCase(commentId, userPrincipal.userId)
 
-        return ResponseEntity.ok("댓글을 삭제했습니다.")
+        return ResponseEntity.ok(DeleteCommentResponse(true))
     }
 }

--- a/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
@@ -7,6 +7,7 @@ import com.routebox.routebox.application.comment.WriteCommentUseCase
 import com.routebox.routebox.controller.comment.dto.GetAllCommentsOfPostResponse
 import com.routebox.routebox.controller.comment.dto.PatchModifyCommentRequest
 import com.routebox.routebox.controller.comment.dto.PostWriteCommentRequest
+import com.routebox.routebox.controller.comment.dto.PostWriteCommentResponse
 import com.routebox.routebox.security.UserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -50,7 +51,7 @@ class CommentController(
     fun writeComment(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @RequestBody request: PostWriteCommentRequest,
-    ): ResponseEntity<String> {
+    ): ResponseEntity<PostWriteCommentResponse> {
         // 댓글을 작성한다
         writeCommentUseCase(
             userId = userPrincipal.userId,
@@ -58,7 +59,7 @@ class CommentController(
             content = request.content,
         )
 
-        return ResponseEntity.ok("댓글 작성이 완료되었습니다.")
+        return ResponseEntity.ok(PostWriteCommentResponse(true))
     }
 
     @Operation(

--- a/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/comment/CommentController.kt
@@ -6,6 +6,7 @@ import com.routebox.routebox.application.comment.ModifyCommentUseCase
 import com.routebox.routebox.application.comment.WriteCommentUseCase
 import com.routebox.routebox.controller.comment.dto.GetAllCommentsOfPostResponse
 import com.routebox.routebox.controller.comment.dto.PatchModifyCommentRequest
+import com.routebox.routebox.controller.comment.dto.PatchModifyCommentResponse
 import com.routebox.routebox.controller.comment.dto.PostWriteCommentRequest
 import com.routebox.routebox.controller.comment.dto.PostWriteCommentResponse
 import com.routebox.routebox.security.UserPrincipal
@@ -92,10 +93,10 @@ class CommentController(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PathVariable commentId: Long,
         @RequestBody @Valid request: PatchModifyCommentRequest,
-    ): ResponseEntity<String> {
+    ): ResponseEntity<PatchModifyCommentResponse> {
         modifyCommentUseCase(commentId, request.content, userPrincipal.userId)
 
-        return ResponseEntity.ok("댓글 수정을 완료했습니다.")
+        return ResponseEntity.ok(PatchModifyCommentResponse(true))
     }
 
     @Operation(

--- a/src/main/kotlin/com/routebox/routebox/controller/comment/dto/DeleteCommentResponse.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/comment/dto/DeleteCommentResponse.kt
@@ -1,0 +1,8 @@
+package com.routebox.routebox.controller.comment.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class DeleteCommentResponse(
+    @Schema(description = "요청 성공 여부: true(성공), false(실패)", example = "true")
+    val isSuccess: Boolean,
+)

--- a/src/main/kotlin/com/routebox/routebox/controller/comment/dto/PatchModifyCommentResponse.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/comment/dto/PatchModifyCommentResponse.kt
@@ -2,7 +2,7 @@ package com.routebox.routebox.controller.comment.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-data class PostWriteCommentResponse(
+data class PatchModifyCommentResponse(
     @Schema(description = "요청 성공 여부: true(성공), false(실패)", example = "true")
     val isSuccess: Boolean,
 )

--- a/src/main/kotlin/com/routebox/routebox/controller/comment/dto/PostWriteCommentResponse.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/comment/dto/PostWriteCommentResponse.kt
@@ -1,0 +1,8 @@
+package com.routebox.routebox.controller.comment.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+class PostWriteCommentResponse(
+    @Schema(description = "요청 성공 여부: true(성공), false(실패)", example = "true")
+    val isSuccess: Boolean,
+)


### PR DESCRIPTION
[변경사항]

- 댓글 도메인에서, 응답 타입이 String으로 되어있는 API에 한해 Dto를 만들어 응답하도록 수정했습니다.
: 수정 이유 = 편리한 작업을 위한 프론트엔드 요구사항 반영