### PR TITLE
[루트 구매 API] 포인트로 구매 시, 보유 포인트가 부족한 경우에 대한 예외처리 추가

### DIFF
--- a/src/main/kotlin/com/routebox/routebox/application/route/PurchaseRouteUseCase.kt
+++ b/src/main/kotlin/com/routebox/routebox/application/route/PurchaseRouteUseCase.kt
@@ -13,6 +13,7 @@ import com.routebox.routebox.domain.user_point_history.UserPointHistory
 import com.routebox.routebox.domain.user_point_history.UserPointHistoryService
 import com.routebox.routebox.exception.coupon.NoAvailableCouponException
 import com.routebox.routebox.exception.route.RouteNotFoundException
+import com.routebox.routebox.exception.user.InsufficientPointException
 import com.routebox.routebox.exception.user.UserNotFoundException
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -33,6 +34,7 @@ class PurchaseRouteUseCase(
      * @throws NoAvailableCouponException (쿠폰으로 구매 시) 이용 가능한 쿠폰이 없는 경우
      * @throws UserNotFoundException `buyerId`에 해당하는 유저가 없는 경우
      * @throws RouteNotFoundException `routeId`에 해당하는, 구매할 루트 정보가 없는 경우
+     * @throws InsufficientPointException (포인트로 구매 시) 루트를 구매하기에 포인트가 부족한 경우
      */
     @Transactional
     operator fun invoke(command: PurchaseRouteCommand) {

--- a/src/main/kotlin/com/routebox/routebox/controller/route/RouteController.kt
+++ b/src/main/kotlin/com/routebox/routebox/controller/route/RouteController.kt
@@ -105,7 +105,12 @@ class RouteController(
     )
     @ApiResponses(
         ApiResponse(responseCode = "200"),
-        ApiResponse(responseCode = "400", description = "[3003] (쿠폰으로 구매 시) 이용 가능한 쿠폰이 없는 경우", content = [Content()]),
+        ApiResponse(
+            responseCode = "400",
+            description = "<p>[3003] (쿠폰으로 구매 시) 이용 가능한 쿠폰이 없는 경우" +
+                "<p>[3005] (포인트로 구매 시) 루트를 구매하기에 포인트가 부족한 경우",
+            content = [Content()],
+        ),
     )
     @PostMapping("/v1/routes/{routeId}/purchase")
     fun purchaseRoute(

--- a/src/main/kotlin/com/routebox/routebox/domain/user/User.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/user/User.kt
@@ -124,4 +124,6 @@ class User(
     fun rejoin() {
         this.deletedAt = LocalDateTime.now()
     }
+
+    fun canPurchase(point: Int): Boolean = this.point >= point
 }

--- a/src/main/kotlin/com/routebox/routebox/domain/user/UserService.kt
+++ b/src/main/kotlin/com/routebox/routebox/domain/user/UserService.kt
@@ -3,6 +3,7 @@ package com.routebox.routebox.domain.user
 import com.routebox.routebox.domain.common.FileManager
 import com.routebox.routebox.domain.user.constant.Gender
 import com.routebox.routebox.domain.user.constant.LoginType
+import com.routebox.routebox.exception.user.InsufficientPointException
 import com.routebox.routebox.exception.user.UserNicknameDuplicationException
 import com.routebox.routebox.exception.user.UserNotFoundException
 import com.routebox.routebox.exception.user.UserSocialLoginUidDuplicationException
@@ -139,8 +140,8 @@ class UserService(
     @Transactional
     fun usePoint(userId: Long, point: Int): User {
         val user = getUserById(userId)
-        if (user.point < point) {
-            TODO("잔여 포인트가 부족할 경우 예외 발생")
+        if (user.canPurchase(point)) {
+            throw InsufficientPointException()
         }
         user.usePoint(point)
         return user

--- a/src/main/kotlin/com/routebox/routebox/exception/CustomExceptionType.kt
+++ b/src/main/kotlin/com/routebox/routebox/exception/CustomExceptionType.kt
@@ -27,6 +27,7 @@ enum class CustomExceptionType(
     USER_NICKNAME_DUPLICATION(3002, "이미 사용중인 닉네임입니다."),
     NO_AVAILABLE_COUPON(3003, "이용 가능한 쿠폰이 없습니다."),
     USER_WITHDRAWN(3004, "탈퇴한 유저입니다."),
+    INSUFFICIENT_POINT(3005, "포인트가 부족합니다."),
 
     /**
      * 루트 관련 예외

--- a/src/main/kotlin/com/routebox/routebox/exception/user/InsufficientPointException.kt
+++ b/src/main/kotlin/com/routebox/routebox/exception/user/InsufficientPointException.kt
@@ -1,0 +1,6 @@
+package com.routebox.routebox.exception.user
+
+import com.routebox.routebox.exception.CustomExceptionType
+import com.routebox.routebox.exception.common.BadRequestException
+
+class InsufficientPointException : BadRequestException(exceptionType = CustomExceptionType.INSUFFICIENT_POINT)


### PR DESCRIPTION
Closed #140

- 루트 구매 API 포인트로 구매 시, 보유 포인트가 부족한 경우에 대한 예외처리 추가